### PR TITLE
faster-c: faster_start_session: Return copy of guid string

### DIFF
--- a/cc/src/core/faster-c.cc
+++ b/cc/src/core/faster-c.cc
@@ -337,7 +337,9 @@ extern "C" {
     } else {
       store_t* store = faster_t->obj;
       Guid guid = store->StartSession();
-      return guid.ToString().c_str();
+      char* str = new char[37];
+      std::strcpy(str, guid.ToString().c_str());
+      return str;
     }
 
   }


### PR DESCRIPTION
What: Return a copy of the GUID string

Why: Currently the returned string is deallocated before it can be dereferenced