### PR TITLE
Pass reads to Rust

### DIFF
--- a/cc/playground/c_test/c_test.c
+++ b/cc/playground/c_test/c_test.c
@@ -1,12 +1,13 @@
 #include "c_test.h"
+#include "core/faster-c.h"
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <inttypes.h>
 
-
-void callback(void* func) {
-    printf("hej\n");
+void callback(void* func, uint64_t x, faster_status status) {
+  printf("%d\n", x);
 }
 
 
@@ -26,10 +27,10 @@ int main() {
   assert(rmw == 0);
 
   // Read
-  uint8_t res = faster_read(store, 1);
-  uint8_t resTwo = faster_read(store, 2);
-  uint8_t resThree = faster_read(store, 3);
-  uint8_t resFour = faster_read(store, 4);
+  uint8_t res = faster_read(store, 1, callback, NULL);
+  uint8_t resTwo = faster_read(store, 2, callback, NULL);
+  uint8_t resThree = faster_read(store, 3, callback, NULL);
+  uint8_t resFour = faster_read(store, 4, callback, NULL);
 
   // Status: 0 == Ok, 2 == NotFound
   assert(res == 0);

--- a/cc/src/core/faster-c.h
+++ b/cc/src/core/faster-c.h
@@ -20,6 +20,19 @@ extern "C" {
   typedef struct faster_result faster_result;
   typedef void (*faster_callback)(faster_result);
 
+  enum faster_status {
+      Ok,
+      Pending,
+      NotFound,
+      OutOfMemory,
+      IOError,
+      Corrupted,
+      Aborted
+  };
+  typedef enum faster_status faster_status;
+
+  typedef void (*read_callback)(void*, uint64_t, faster_status);
+
   typedef struct faster_checkpoint_result faster_checkpoint_result;
   struct faster_checkpoint_result {
     bool checked;
@@ -44,7 +57,7 @@ extern "C" {
   faster_t* faster_open_with_disk(const uint64_t table_size, const uint64_t log_size, const char* storage);
   uint8_t faster_upsert(faster_t* faster_t, const uint64_t key, const uint64_t value);
   uint8_t faster_rmw(faster_t* faster_t, const uint64_t key, const uint64_t value);
-  uint8_t faster_read(faster_t* faster_t, const uint64_t key);
+  uint8_t faster_read(faster_t* faster_t, const uint64_t key, read_callback cb, void* target);
   faster_checkpoint_result* faster_checkpoint(faster_t* faster_t);
   void faster_destroy(faster_t* faster_t);
   uint64_t faster_size(faster_t* faster_t);


### PR DESCRIPTION
What: return read values to Rust callback along with status flag

Why: 
* callback in Rust can send values down the channel
* needs to know status in case the value was not found and channel needs to be closed

See https://github.com/Max-Meldrum/faster-rs/pull/1