### PR TITLE
Support null disk

### DIFF
--- a/cc/src/core/faster-c.h
+++ b/cc/src/core/faster-c.h
@@ -55,6 +55,7 @@ extern "C" {
   void faster_refresh_session(faster_t* faster_t);
 
   // Operations
+  faster_t* faster_open(const uint64_t table_size, const uint64_t log_size);
   faster_t* faster_open_with_disk(const uint64_t table_size, const uint64_t log_size, const char* storage);
   uint8_t faster_upsert(faster_t* faster_t, const uint64_t key, uint8_t* value,
                         uint64_t length, const uint64_t monotonic_serial_number);


### PR DESCRIPTION
What:
* add a new method to make a FASTER instance with a null disk
* update other methods to use either instance
Why:
* eventually add support in Rust Wrapper (See https://github.com/Max-Meldrum/faster-rs/issues/14)