### PR TITLE
Support arbitrary keys

### DIFF
--- a/cc/benchmark-dir/benchmark-c.cc
+++ b/cc/benchmark-dir/benchmark-c.cc
@@ -233,8 +233,11 @@ void thread_setup_store(faster_t* store, size_t thread_idx) {
 
       uint8_t* val = new uint8_t[1];
       val[0] = value;
-      faster_upsert(store, init_keys_.get()[idx], val, 1, 1);
+      uint8_t* key = new uint8_t[8];
+      memcpy(key, &init_keys_.get()[idx], 8);
+      faster_upsert(store, key, 8, val, 1, 1);
       free(val);
+      free(key);
     }
   }
 
@@ -296,8 +299,11 @@ void thread_run_benchmark(faster_t* store, size_t thread_idx) {
       case Op::Upsert: {
         uint8_t* val = new uint8_t[1];
         val[0] = upsert_value;
-        faster_upsert(store, txn_keys_.get()[idx], val, 1, 1);
+        uint8_t* key = new uint8_t[8];
+        memcpy(key, &txn_keys_.get()[idx], 8);
+        faster_upsert(store, key, 8, val, 1, 1);
         free(val);
+        free(key);
         ++writes_done;
         break;
       }
@@ -306,15 +312,21 @@ void thread_run_benchmark(faster_t* store, size_t thread_idx) {
         exit(1);
         break;
       case Op::Read: {
-        faster_read(store, txn_keys_.get()[idx], 1, read_cb, NULL);
+        uint8_t* key = new uint8_t[8];
+        memcpy(key, &txn_keys_.get()[idx], 8);
+        faster_read(store, key, 8, 1, read_cb, NULL);
+        free(key);
         ++reads_done;
         break;
       }
       case Op::ReadModifyWrite:
         uint8_t* modification = new uint8_t[1];
         modification[0] = 0;
-        uint8_t result = faster_rmw(store, txn_keys_.get()[idx], modification, 1, 1, rmw_cb);
+        uint8_t* key = new uint8_t[8];
+        memcpy(key, &txn_keys_.get()[idx], 8);
+        uint8_t result = faster_rmw(store, key, 8, modification, 1, 1, rmw_cb);
         free(modification);
+        free(key);
         if(result == 0) {
           ++writes_done;
         }

--- a/cc/src/core/faster-c.h
+++ b/cc/src/core/faster-c.h
@@ -57,12 +57,12 @@ extern "C" {
   // Operations
   faster_t* faster_open(const uint64_t table_size, const uint64_t log_size);
   faster_t* faster_open_with_disk(const uint64_t table_size, const uint64_t log_size, const char* storage);
-  uint8_t faster_upsert(faster_t* faster_t, const uint64_t key, uint8_t* value,
-                        uint64_t length, const uint64_t monotonic_serial_number);
-  uint8_t faster_rmw(faster_t* faster_t, const uint64_t key, uint8_t* modification, const uint64_t length,
-                     const uint64_t monotonic_serial_number, rmw_callback cb);
-  uint8_t faster_read(faster_t* faster_t, const uint64_t key, const uint64_t monotonic_serial_number,
-                      read_callback cb, void* target);
+  uint8_t faster_upsert(faster_t* faster_t, const uint8_t* key, const uint64_t key_length,
+                        uint8_t* value, uint64_t value_length, const uint64_t monotonic_serial_number);
+  uint8_t faster_rmw(faster_t* faster_t, const uint8_t* key, const uint64_t key_length, uint8_t* modification,
+                     const uint64_t length, const uint64_t monotonic_serial_number, rmw_callback cb);
+  uint8_t faster_read(faster_t* faster_t, const uint8_t* key, const uint64_t key_length,
+                       const uint64_t monotonic_serial_number, read_callback cb, void* target);
   faster_checkpoint_result* faster_checkpoint(faster_t* faster_t);
   void faster_destroy(faster_t* faster_t);
   uint64_t faster_size(faster_t* faster_t);

--- a/cc/src/core/utility.h
+++ b/cc/src/core/utility.h
@@ -30,6 +30,23 @@ class Utility {
     //    e => 40343 * (40343 * (40343 * (40343 * (40343 * 8 + (long)((e) & 0xFFFF)) + (long)((e >> 16) & 0xFFFF)) + (long)((e >> 32) & 0xFFFF)) + (long)(e >> 48));
   }
 
+  static inline uint64_t Hash8BitBytes(const uint8_t* str, size_t len) {
+    // 40343 is a "magic constant" that works well,
+    // 38299 is another good value.
+    // Both are primes and have a good distribution of bits.
+    const uint64_t kMagicNum = 40343;
+    uint64_t hashState = len;
+
+    for(size_t idx = 0; idx < len; ++idx) {
+      hashState = kMagicNum * hashState + str[idx];
+    }
+
+    // The final scrambling helps with short keys that vary only on the high order bits.
+    // Low order bits are not always well distributed so shift them to the high end, where they'll
+    // form part of the 14-bit tag.
+    return Rotr64(kMagicNum * hashState, 6);
+  }
+
   static inline uint64_t HashBytes(const uint16_t* str, size_t len) {
     // 40343 is a "magic constant" that works well,
     // 38299 is another good value.


### PR DESCRIPTION
What:
* store arbitrary keys that have been serialised to byte array

Why:
* possibilities are endless

See https://github.com/faster-rs/faster-rs/issues/4